### PR TITLE
Add basic ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "rules": {
+    "no-console": ["warn", { "allow": ["group", "groupCollapsed"] }],
+    "quote-props": [2, "as-needed"],
+    "id-length": ["warn", { "exceptions": ["_", "j", "i", "x", "y", "Q"] }],
+    "comma-dangle": [1, {
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "arrays": "always-multiline",
+      "functions": "never"
+    }],
+    "curly": 2,
+    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^_+$" }],
+    "camelcase": [1, { "ignoreDestructuring": true, "properties": "never" }],
+    "multiline-ternary": ["warn", "always-multiline"],
+    "brace-style": ["warn", "1tbs", { "allowSingleLine": true }],
+    "operator-linebreak": ["error", "after", { "overrides": { "?": "ignore", ":": "ignore" } }],
+    "indent": [1, 2, { "SwitchCase": 1, "ignoredNodes": ["TemplateLiteral"] }],
+    "linebreak-style": [2, "unix"],
+    "quotes": [2, "single"],
+    "block-spacing": ["warn", "always"],
+    "semi": 0
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple ESLint configuration for TypeScript

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685bbf33cb708329b64199a00d9314dd