### PR TITLE
Add ESLint script and dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "rules": {
+    "no-console": ["warn", { "allow": ["group", "groupCollapsed"] }],
+    "quote-props": [2, "as-needed"],
+    "id-length": ["warn", { "exceptions": ["_", "j", "i", "x", "y", "Q"] }],
+    "comma-dangle": [1, {
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "arrays": "always-multiline",
+      "functions": "never"
+    }],
+    "curly": 2,
+    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^_+$" }],
+    "camelcase": [1, { "ignoreDestructuring": true, "properties": "never" }],
+    "multiline-ternary": ["warn", "always-multiline"],
+    "brace-style": ["warn", "1tbs", { "allowSingleLine": true }],
+    "operator-linebreak": ["error", "after", { "overrides": { "?": "ignore", ":": "ignore" } }],
+    "indent": [1, 2, { "SwitchCase": 1, "ignoredNodes": ["TemplateLiteral"] }],
+    "linebreak-style": [2, "unix"],
+    "quotes": [2, "single"],
+    "block-spacing": ["warn", "always"],
+    "semi": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "scripts": {
         "build": "rollup -c",
-        "watch": "rollup -c -w --watch.onEnd=\"streamdeck restart com.mdb.hello-world\""
+        "watch": "rollup -c -w --watch.onEnd=\"streamdeck restart com.mdb.hello-world\"",
+        "lint": "eslint -c .eslintrc.json \"src/**/*.{ts,tsx}\""
     },
     "type": "module",
     "devDependencies": {
@@ -14,7 +15,10 @@
         "@types/node": "~20.15.0",
         "rollup": "^4.0.2",
         "tslib": "^2.6.2",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "eslint": "^8.56.0",
+        "@typescript-eslint/parser": "^6.7.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.0"
     },
     "dependencies": {
         "@elgato/streamdeck": "^1.0.0"


### PR DESCRIPTION
## Summary
- add lint script using ESLint
- install eslint and @typescript-eslint packages

## Testing
- `npm run lint` *(fails: ESLint couldn't find config or parse)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685bbf33cb708329b64199a00d9314dd